### PR TITLE
Strip hints at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ cover
 # Sublime
 *.sublime-project
 *.sublime-workspace
+.ascii_canvas_tmp/
+.mypy*
+.nox
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - '2.6'
   - '2.7'
   - '3.4'
   - '3.5'

--- a/README.md
+++ b/README.md
@@ -2,39 +2,44 @@
 [![Build Status](https://travis-ci.org/PaulSchweizer/ascii-canvas.svg?branch=master)](https://travis-ci.org/PaulSchweizer/ascii-canvas) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1e97852797d14c679d7c89337b022c92)](https://www.codacy.com/app/paulschweizer/ascii-canvas?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=PaulSchweizer/ascii-canvas&amp;utm_campaign=Badge_Grade)
 
 
-# Treat strings like Items on a 2D Canvas
+# Treat Strings like Items on a 2D Canvas
 
 With this primitive library you can do things like this:
 
 ```python
-from ascii_canvas.canvas import Canvas
-from ascii_canvas.item import Item, Line
+from ascii_canvas import canvas
+from ascii_canvas import item
 
-canvas = Canvas()
+canvas_ = canvas.Canvas()
 
-rect_a = Item('+-----+\n|Hello|\n+-----+', position=[0, 0])
-rect_b = Item('+-----+\n|World|\n+-----+', position=[16, 5])
-rect_c = Item('+-+\n|!|\n+-+', position=[32, 0])
-line_a = Line(start=[7, 1], end=[15, 6])
-line_b = Line(start=[23, 6], end=[31, 1])
+rect_a = item.Item('+-----+\n|Hello|\n+-----+', position=[0, 0])
+rect_b = item.Item('+-----+\n|World|\n+-----+', position=[16, 5])
+rect_c = item.Item('+-+\n|!|\n+-+', position=[32, 0])
+line_a = item.Line(start=[7, 1], end=[15, 6])
+line_b = item.Line(start=[23, 6], end=[31, 1])
 
-canvas.add_item(rect_a)
-canvas.add_item(rect_b)
-canvas.add_item(rect_c)
-canvas.add_item(line_a)
-canvas.add_item(line_b)
-print(canvas.draw())
+canvas_.add_item(rect_a)
+canvas_.add_item(rect_b)
+canvas_.add_item(rect_c)
+canvas_.add_item(line_a)
+canvas_.add_item(line_b)
+print(canvas_.draw())
 ```
 
 Which results in this output:
 
 ```
-    0+-----+                         +-+
-    1|Hello|----+               +----|!|
-    2+-----+    |               |    +-+
-    3           |               |
-    4           |               |
-    5           |    +-----+    |
-    6           +----|World|----+
-    7                +-----+
++-----+                         +-+
+|Hello|----+               +----|!|
++-----+    |               |    +-+
+           |               |
+           |               |
+           |    +-----+    |
+           +----|World|----+
+                +-----+
 ```
+
+# Type hints
+
+The library contains Python3.6-style type hints. For lower Python versions the hints are however stripped on the fly with [strip-hints](https://github.com/abarker/strip-hints)!, making ascii-canvas compatible all the way down to Python 2.6.
+Please note that in Python < 3.6 you can NOT import the classes directly due to the stripping of the type hints, so stick with the way that the example imports the module.

--- a/ascii_canvas/__init__.py
+++ b/ascii_canvas/__init__.py
@@ -1,0 +1,24 @@
+"""Stripping the python 3.6 type hints for backwards compatibility."""
+import os
+import sys
+
+
+if sys.version_info.major < 3 or sys.version_info.minor < 6:
+
+    from strip_hints import strip_hints_main, import_hooks
+
+    item_path = os.path.join(os.path.dirname(__file__), 'item.py')
+    canvas_path = os.path.join(os.path.dirname(__file__), 'canvas.py')
+
+    importer = import_hooks.StripHintsImporter()
+    stripper = strip_hints_main.HintStripper(
+        to_empty=False, no_ast=False,
+        no_colon_move=False, only_assigns_and_defs=False)
+    module_dir = os.path.dirname(os.path.realpath(item_path))
+    importer.stripper_fun_to_use[module_dir] = stripper.strip_type_hints_from_file
+
+    importer.module_info = (None, item_path)
+    item = importer.load_module(item_path)
+
+    importer.module_info = (None, canvas_path)
+    canvas = importer.load_module(canvas_path)

--- a/ascii_canvas/canvas.py
+++ b/ascii_canvas/canvas.py
@@ -1,9 +1,12 @@
 """Aggregate items into a string canvas."""
 from __future__ import print_function
 
-from typing import List
+try:
+    from typing import List
+except Exception:
+    pass
 
-from ascii_canvas.item import Item
+from ascii_canvas import item as item_
 
 
 class Canvas(object):
@@ -13,9 +16,9 @@ class Canvas(object):
 
     def __init__(self) -> None:
         """Hold a list of Items."""
-        self.items: List[Item] = []
+        self.items: List[item_.Item] = []
 
-    def add_item(self, item: Item, index: int=-1) -> None:
+    def add_item(self, item: item_.Item, index: int=-1) -> None:
         """Insert the item at the given index."""
         self.items.insert(index, item)
 

--- a/ascii_canvas/item.py
+++ b/ascii_canvas/item.py
@@ -1,7 +1,11 @@
 """Items can be placed on the Canvas."""
 from __future__ import print_function
 
-from typing import List
+
+try:
+    from typing import List
+except ImportError:
+    pass
 
 
 class Item(object):
@@ -22,12 +26,10 @@ class Item(object):
 class Line(Item):
     """A line between two points.
 
-    It is drawn like this:
-
-        START ---+
-                 |
-                 |
-                 +--- END
+    START---+
+            |
+            |
+            +---END
     """
 
     def __init__(self, start: List[int], end: List[int]):
@@ -88,7 +90,6 @@ class Line(Item):
 class Rectangle(Item):
     """A rectangle.
 
-    It looks like this:
     +---+
     |   |
     |   |

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ def static_type(session):
     session.run("mypy", "--ignore-missing-imports", "ascii_canvas")
 
 
-@nox.session(python=["2.6", "2.7", "3.4", "3.5", "3.6"])
+@nox.session(python=["2.7", "3.4", "3.5", "3.6"])
 def pytests_no_hints(session):
     session.install("-r", "test-requirements.txt")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,23 +9,8 @@ def static_type(session):
     session.run("mypy", "--ignore-missing-imports", "ascii_canvas")
 
 
-@nox.session(python=["3.6"])
-def pytests_with_hints(session):
-    session.install("-r", "test-requirements.txt")
-
-    session.run("python", "-m", "pytest", "--spec", "-s", os.path.join("tests"))
-
-
-@nox.session(python=["2.6", "2.7", "3.4", "3.5"])
+@nox.session(python=["2.6", "2.7", "3.4", "3.5", "3.6"])
 def pytests_no_hints(session):
     session.install("-r", "test-requirements.txt")
 
-    session.run("cp", "-a", "ascii_canvas", ".ascii_canvas_tmp", external=True)
-
-    session.run("python", "strip-type-hints.py")
     session.run("python", "-m", "pytest", "--spec", "-s", os.path.join("tests"))
-
-    session.run("rm", "-rf", "ascii_canvas", external=True)
-    session.run("cp", "-a", ".ascii_canvas_tmp", "ascii_canvas", external=True)
-    session.run("rm", "-rf", ".ascii_canvas_tmp", external=True)
-

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,56 +1,89 @@
-from ascii_canvas.canvas import Canvas
-from ascii_canvas.item import Item
-from ascii_canvas.item import Line
-from ascii_canvas.item import Rectangle
+from ascii_canvas import canvas
+from ascii_canvas import item
 
 
 def test_render_items_on_canvas():
     """Render the added items correctly."""
-    canvas = Canvas()
+    canvas_ = canvas.Canvas()
 
-    rect_a = Item('+-----+\n|Hello|\n+-----+', position=[0, 0])
-    rect_b = Item('+-----+\n|World|\n+-----+', position=[16, 5])
-    rect_c = Item('+-+\n|!|\n+-+', position=[32, 0])
-    line_a = Line(start=[7, 1], end=[15, 6])
-    line_b = Line(start=[23, 6], end=[31, 1])
+    rect_a = item.Item('+-----+\n|Hello|\n+-----+', position=[0, 0])
+    rect_b = item.Item('+-----+\n|World|\n+-----+', position=[16, 5])
+    rect_c = item.Item('+-+\n|!|\n+-+', position=[32, 0])
+    line_a = item.Line(start=[7, 1], end=[15, 6])
+    line_b = item.Line(start=[23, 6], end=[31, 1])
 
-    canvas.add_item(rect_a)
-    canvas.add_item(rect_b)
-    canvas.add_item(rect_c)
-    canvas.add_item(line_a)
-    canvas.add_item(line_b)
+    canvas_.add_item(rect_a)
+    canvas_.add_item(rect_b)
+    canvas_.add_item(rect_c)
+    canvas_.add_item(line_a)
+    canvas_.add_item(line_b)
 
-    rendered = canvas.render(line_numbers=False)
-    print(rendered)
+    rendered = canvas_.render(line_numbers=False)
+    assert rendered == '\
++-----+                         +-+\n\
+|Hello|----+               +----|!|\n\
++-----+    |               |    +-+\n\
+           |               |       \n\
+           |               |       \n\
+           |    +-----+    |       \n\
+           +----|World|----+       \n\
+                +-----+            '
 
-    rendered = canvas.render(line_numbers=True)
-    print(rendered)
+    rendered = canvas_.render(line_numbers=True)
+    assert rendered == '\
+   7 ^+-----+                         +-+\n\
+   6 ||Hello|----+               +----|!|\n\
+   5 |+-----+    |               |    +-+\n\
+   4 |           |               |       \n\
+   3 |           |               |       \n\
+   2 |           |    +-----+    |       \n\
+   1 |           +----|World|----+       \n\
+   0 |                +-----+            \n\
+     +---------------------------------->\n\
+      01234567891111111111222222222233333\n\
+                0123456789012345678901234'
 
 
 def test_rectangle():
     """Render a bunch of rectangles."""
-    canvas = Canvas()
+    canvas_ = canvas.Canvas()
+    canvas.Canvas.BLANK = '.'
 
-    null_rect = Rectangle(width=0, height=0)
-    canvas.add_item(null_rect)
+    null_rect = item.Rectangle(width=0, height=0)
+    canvas_.add_item(null_rect)
 
-    null_hor_rect = Rectangle(width=0, height=1, position=[5, 0])
-    canvas.add_item(null_hor_rect)
+    null_hor_rect = item.Rectangle(width=0, height=1, position=[5, 0])
+    canvas_.add_item(null_hor_rect)
 
-    null_ver_rect = Rectangle(width=1, height=0, position=[10, 0])
-    canvas.add_item(null_ver_rect)
+    null_ver_rect = item.Rectangle(width=1, height=0, position=[10, 0])
+    canvas_.add_item(null_ver_rect)
 
-    three_by_three_quad = Rectangle(width=3, height=3, position=[15, 0])
-    canvas.add_item(three_by_three_quad)
+    three_by_three_quad = item.Rectangle(width=3, height=3, position=[15, 0])
+    canvas_.add_item(three_by_three_quad)
 
-    rect = Rectangle(width=4, height=9, position=[0, 5],
+    rect = item.Rectangle(width=4, height=9, position=[0, 5],
                      horizontal_border='H', vertical_border='V',
                      corner='C', fill='F')
-    canvas.add_item(rect)
+    canvas_.add_item(rect)
 
-    rect = Rectangle(width=4, height=5, position=[10, 5],
-                     horizontal_border='.', vertical_border='.',
-                     corner='.', fill=' ')
-    canvas.add_item(rect)
+    rect = item.Rectangle(width=4, height=5, position=[10, 5],
+                     horizontal_border='~', vertical_border='/',
+                     corner='#', fill=' ')
+    canvas_.add_item(rect)
 
-    print(canvas.render(line_numbers=False))
+    assert canvas_.render(line_numbers=False) == '''\
+...............+-+
+...............|.|
+...............+-+
+..................
+..................
+CHHC......#~~#....
+VFFV....../../....
+VFFV....../../....
+VFFV....../../....
+VFFV......#~~#....
+VFFV..............
+VFFV..............
+VFFV..............
+CHHC..............
+..................'''


### PR DESCRIPTION
Hey @Anton-4 , I found a way to strip the type hints on runtime for py < 3.6, please take a look if you have a minute and let me know if you have any concerns